### PR TITLE
Refactor actions' arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,35 +41,36 @@ require('activeadmin_dynamic_fields')
 
 ## Options
 
-Options are passed to fields using *input_html* parameter as *data* attributes.
+Options are passed to form fields via *data* attributes (in *input_html* parameter).
 
 Conditions:
 
 - **data-if**: check a condition, values:
-  + **checked**: check if a checkbox is checked (ex. `"data-if": "checked"`)
-  + **not_checked**: check if a checkbox is not checked (equivalent to `"data-if": "!checked"`)
+  + **checked**: check if a checkbox is checked (ex. `data: { if: "checked" }`)
+  + **not_checked**: check if a checkbox is not checked (equivalent to `data: { if: "!checked" }`)
   + **blank**: check if a field is blank
   + **not_blank**: check if a field is not blank
   + **changed**: check if the value of an input is changed (dirty)
-- **data-eq**: check if a field has a specific value (ex. `"data-eq": "42"` or `"data-eq": "!5"`)
-- **data-not**: check if a field has not a specific value (equivalent to `"data-eq": "!something"`)
+- **data-eq**: check if a field has a specific value (ex. `data: { eq: "42" }` or `data: { eq: "!5" }`)
+- **data-not**: check if a field has not a specific value (equivalent to `data: { eq: "!something" }`)
 - **data-match**: check if a field match a regexp
-- **data-mismatch**: check if a field doesn't match a regexp (ex. `"data-mismatch": "^\d+$"`)
-- **data-function**: check the return value of a custom function (ex. `"data-function": "my_check"`)
+- **data-mismatch**: check if a field doesn't match a regexp (ex. `data: { mismatch: "^\d+$" }`)
+- **data-function**: check the return value of a custom function (ex. `data: { function: "my_check" }`)
 
 Actions:
 
 - **data-then**: action to trigger (alias **data-action**), values:
-  + **hide**: hides elements (ex. `"data-then": "hide", "data-target": ".errors"`)
+  + **hide**: hides elements (ex. `data: { then: "hide", target: ".errors" }`)
   + **slide**: hides elements (using sliding)
   + **fade**: hides elements (using fading)
-  + **addClass**: adds classes (ex. `"data-then": "addClass red"`)
-  + **addStyle**: adds some styles (ex. `"data-then": "addStyle color: #fb1; font-size: 12px"`)
-  + **setText**: set the text of an element (ex. `"data-then": "setText A sample text"`)
-  + **setValue**: set the value of an input element (ex. `"data-then": "setValue A sample value"`)
-  + **callback**: call a function (with arguments: **data-args**) (ex. `"data-then": "callback a_fun"`)
-- **data-else**: action to trigger when the condition check is not true
-- **data-args**: arguments passed to the callback function
+  + **addClass**: adds classes (ex. `data: { then: "addClass", args: "red", target: "#something"}`)
+  + **addStyle**: adds some styles (ex. `data: { then: "addStyle", args: "color: #fb1; font-size: 12px" }`)
+  + **setText**: set the text of an element (ex. `data: { then: "setText", args: "A sample text" }`)
+  + **setValue**: set the value of an input element (ex. `data: { then: "setValue", args: "A sample value" }`)
+  + **callback**: call a function (with arguments: **data-args**) (ex. `data: { then: "callback" }`)
+- **data-args**: extra arguments for the action, for callback action this parameter is the name of the JS function to call
+- **data-else**: action to trigger when the condition check is not true (ex. `data: { else: "fade" }`)
+- **data-else-args**: extra arguments for the else action (ex. `data: { else: "addClass", else_args: "red" }`)
 
 Targets:
 
@@ -98,14 +99,14 @@ end
 - Add 3 classes (*first*, *second*, *third*) if a checkbox is not checked, else add "forth" class:
 
 ```rb
-data = { if: 'not_checked', then: 'addClass first second third', target: '.grp1', else: 'addClass forth' }
+data = { if: 'not_checked', then: 'addClass', args: 'first second third', target: '.grp1', else: 'addClass', elseArgs: 'forth' }
 f.input :published, input_html: { data: data }
 ```
 
 - Set another field value if a string field is blank:
 
 ```rb
-f.input :title, input_html: { data: { if: 'blank', then: 'setValue 10', target: '#article_position' } }
+f.input :title, input_html: { data: { if: 'blank', then: 'setValue', args: '10', target: '#article_position' } }
 ```
 
 - Use a custom function for conditional check (*title_not_empty()* must be available on global scope) (with alternative syntax for data attributes):
@@ -124,16 +125,13 @@ function title_empty(el) {
 - Call a callback function as action:
 
 ```rb
-data = { if: 'checked', then: 'callback set_title', args: '["Unpublished !"]' }
+data = { if: 'checked', then: 'callback', args: 'set_title' }
 f.input :published, input_html: { data: data }
 ```
 
 ```js
-function set_title(args) {
-  if($('#article_title').val().trim() === '') {
-    $('#article_title').val(args[0]);
-    $('#article_title').trigger('change');
-  }
+function set_title(el) {
+  console.log(el.value());
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ Actions:
   + **addStyle**: adds some styles (ex. `data: { then: "addStyle", args: "color: #fb1; font-size: 12px" }`)
   + **setText**: set the text of an element (ex. `data: { then: "setText", args: "A sample text" }`)
   + **setValue**: set the value of an input element (ex. `data: { then: "setValue", args: "A sample value" }`)
-  + **callback**: call a function (with arguments: **data-args**) (ex. `data: { then: "callback" }`)
-- **data-args**: extra arguments for the action, for callback action this parameter is the name of the JS function to call
+  + **callback**: call a function (**data-args** for arguments) (ex. `data: { then: "callback", callback: "myFunction" }`)
+- **data-args**: extra arguments for the action
 - **data-else**: action to trigger when the condition check is not true (ex. `data: { else: "fade" }`)
 - **data-else-args**: extra arguments for the else action (ex. `data: { else: "addClass", else_args: "red" }`)
 
@@ -125,13 +125,13 @@ function title_empty(el) {
 - Call a callback function as action:
 
 ```rb
-data = { if: 'checked', then: 'callback', args: 'set_title' }
+data = { if: 'checked', then: 'callback', callback: 'set_title', args: 'Some title' }
 f.input :published, input_html: { data: data }
 ```
 
 ```js
-function set_title(el) {
-  console.log(el.value());
+function set_title(el, text) {
+  console.log(text);
 }
 ```
 

--- a/app/assets/javascripts/activeadmin/dynamic_fields.js
+++ b/app/assets/javascripts/activeadmin/dynamic_fields.js
@@ -80,8 +80,8 @@
       const action = this.el.data('then') || this.el.data('action') || ''
       const else_action = this.el.data('else') || ''
 
+      this.action_arg = action == 'callback' ? this.el.data('callback') : this.el.data('args')
       this.action = ACTIONS[action]
-      this.action_arg = this.el.data('args')
       this.reverse_action = REVERSE_ACTIONS[action]
       this.else_action = ACTIONS[else_action]
       this.else_action_arg = this.el.data('elseArgs')

--- a/app/assets/javascripts/activeadmin/dynamic_fields.js
+++ b/app/assets/javascripts/activeadmin/dynamic_fields.js
@@ -78,18 +78,16 @@
 
     evaluateAction() {
       const action = this.el.data('then') || this.el.data('action') || ''
-      const action_name = action.split(' ', 1)[0]
       const else_action = this.el.data('else') || ''
-      const else_action_name = else_action.split(' ', 1)[0]
 
-      this.action = ACTIONS[action_name]
-      this.action_arg = action.substring(action.indexOf(' ') + 1)
-      this.reverse_action = REVERSE_ACTIONS[action_name]
-      this.else_action = ACTIONS[else_action_name]
-      this.else_action_arg = else_action.substring(else_action.indexOf(' ') + 1)
-      this.else_reverse_action = REVERSE_ACTIONS[else_action_name]
+      this.action = ACTIONS[action]
+      this.action_arg = this.el.data('args')
+      this.reverse_action = REVERSE_ACTIONS[action]
+      this.else_action = ACTIONS[else_action]
+      this.else_action_arg = this.el.data('elseArgs')
+      this.else_reverse_action = REVERSE_ACTIONS[else_action]
 
-      return action_name
+      return action
     }
 
     evaluateCondition() {

--- a/spec/dummy/app/admin/authors.rb
+++ b/spec/dummy/app/admin/authors.rb
@@ -8,7 +8,7 @@ ActiveAdmin.register Author do
     context = Arbre::Context.new do
       dl do
         %i[name age created_at].each do |field|
-          dt Author.human_attribute_name(field) + ':'
+          dt "#{Author.human_attribute_name(field)}:"
           dd record[field]
         end
       end
@@ -53,7 +53,7 @@ ActiveAdmin.register Author do
               hint: (object.avatar.attached? ? "Current: #{object.avatar.filename}" : nil)
     end
     f.has_many :profile, allow_destroy: true do |ff|
-      dyn_description = { if: 'not_blank', then: 'addClass red', gtarget: 'body' }
+      dyn_description = { if: 'not_blank', then: 'addClass', args: 'red', gtarget: 'body' }
       ff.input :description, input_html: { data: dyn_description }
     end
     f.actions

--- a/spec/dummy/app/admin/posts.rb
+++ b/spec/dummy/app/admin/posts.rb
@@ -127,7 +127,7 @@ ActiveAdmin.register Post do
       add_field(f, :data_field_211, :boolean, df211)
 
       # --- callback
-      df221 = { if: 'checked', then: 'callback', args: 'test_callback' }
+      df221 = { if: 'checked', then: 'callback', callback: 'test_callback', args: 'some_class' }
       add_field(f, :data_field_221, :boolean, df221)
 
       df222 = { if: 'checked', then: 'callback', args: 'missing_callback' }

--- a/spec/dummy/app/admin/posts.rb
+++ b/spec/dummy/app/admin/posts.rb
@@ -51,90 +51,90 @@ ActiveAdmin.register Post do
       f.input :data_test, as: :string
 
       # --- if
-      df111 = { if: 'checked', then: 'addClass red', target: '#post_data_field_111_input label' }
+      df111 = { if: 'checked', then: 'addClass', args: 'red', target: '#post_data_field_111_input label' }
       add_field(f, :data_field_111, :boolean, df111)
 
-      df112 = { if: '!checked', then: 'addClass red', target: '#post_data_field_112_input label' }
+      df112 = { if: '!checked', then: 'addClass', args: 'red', target: '#post_data_field_112_input label' }
       add_field(f, :data_field_112, :boolean, df112)
 
-      df121 = { if: 'not_checked', then: 'addClass red', target: '#post_data_field_121_input label' }
+      df121 = { if: 'not_checked', then: 'addClass', args: 'red', target: '#post_data_field_121_input label' }
       add_field(f, :data_field_121, :boolean, df121)
 
-      df131 = { if: 'blank', then: 'addClass red', target: '#post_data_field_131_input label' }
+      df131 = { if: 'blank', then: 'addClass', args: 'red', target: '#post_data_field_131_input label' }
       add_field(f, :data_field_131, :string, df131)
 
-      df132 = { if: 'blank', then: 'addClass red', target: '#post_data_field_132_input label' }
+      df132 = { if: 'blank', then: 'addClass', args: 'red', target: '#post_data_field_132_input label' }
       add_field(f, :data_field_132, :text, df132)
 
-      df141 = { if: 'not_blank', then: 'addClass red', target: '#post_data_field_141_input label' }
+      df141 = { if: 'not_blank', then: 'addClass', args: 'red', target: '#post_data_field_141_input label' }
       add_field(f, :data_field_141, :string, df141)
 
-      df142 = { if: 'not_blank', then: 'addClass red', target: '#post_data_field_142_input label' }
+      df142 = { if: 'not_blank', then: 'addClass', args: 'red', target: '#post_data_field_142_input label' }
       add_field(f, :data_field_142, :text, df142)
 
-      df151 = { if: 'changed', then: 'addClass red', target: '#post_data_field_151_input label' }
+      df151 = { if: 'changed', then: 'addClass', args: 'red', target: '#post_data_field_151_input label' }
       add_field(f, :data_field_151, :boolean, df151)
 
-      df152 = { if: 'changed', then: 'addClass red', target: '#post_data_field_152_input label' }
+      df152 = { if: 'changed', then: 'addClass', args: 'red', target: '#post_data_field_152_input label' }
       add_field(f, :data_field_152, :string, df152)
 
-      df153 = { if: 'changed', then: 'addClass red', target: '#post_data_field_153_input label' }
+      df153 = { if: 'changed', then: 'addClass', args: 'red', target: '#post_data_field_153_input label' }
       add_field(f, :data_field_153, :text, df153)
 
       # --- eq
-      df161 = { eq: '161', then: 'addClass red', target: '#post_data_field_161_input label' }
+      df161 = { eq: '161', then: 'addClass', args: 'red', target: '#post_data_field_161_input label' }
       add_field(f, :data_field_161, :string, df161)
 
-      df162 = { eq: '162', then: 'addClass red', target: '#post_data_field_162_input label' }
+      df162 = { eq: '162', then: 'addClass', args: 'red', target: '#post_data_field_162_input label' }
       add_field(f, :data_field_162, :select, df162, collection: [161, 162, 163])
 
-      df163 = { eq: '163', then: 'addClass red', target: '#post_data_field_163_input label' }
+      df163 = { eq: '163', then: 'addClass', args: 'red', target: '#post_data_field_163_input label' }
       add_field(f, :data_field_163, :text, df163)
 
-      df164 = { eq: '!164', then: 'addClass red', target: '#post_data_field_164_input label' }
+      df164 = { eq: '!164', then: 'addClass', args: 'red', target: '#post_data_field_164_input label' }
       add_field(f, :data_field_164, :string, df164)
 
       # --- not
-      df171 = { not: '171', then: 'addClass red', target: '#post_data_field_171_input label' }
+      df171 = { not: '171', then: 'addClass', args: 'red', target: '#post_data_field_171_input label' }
       add_field(f, :data_field_171, :string, df171)
 
-      df172 = { not: '172', then: 'addClass red', target: '#post_data_field_172_input label' }
+      df172 = { not: '172', then: 'addClass', args: 'red', target: '#post_data_field_172_input label' }
       add_field(f, :data_field_172, :select, df172, collection: [171, 172, 173])
 
-      df173 = { not: '173', then: 'addClass red', target: '#post_data_field_173_input label' }
+      df173 = { not: '173', then: 'addClass', args: 'red', target: '#post_data_field_173_input label' }
       add_field(f, :data_field_173, :text, df173)
 
       # --- match
-      df181 = { match: 'Something\s', then: 'addClass red', target: '#post_data_field_181_input label' }
+      df181 = { match: 'Something\s', then: 'addClass', args: 'red', target: '#post_data_field_181_input label' }
       add_field(f, :data_field_181, :string, df181)
 
       # --- mismatch
-      df191 = { mismatch: '^\d+$', then: 'addClass red', target: '#post_data_field_191_input label' }
+      df191 = { mismatch: '^\d+$', then: 'addClass', args: 'red', target: '#post_data_field_191_input label' }
       add_field(f, :data_field_191, :string, df191)
 
       # --- function
-      df201 = { function: 'test_fun', then: 'addClass red', target: '#post_data_field_201_input label' }
+      df201 = { function: 'test_fun', then: 'addClass', args: 'red', target: '#post_data_field_201_input label' }
       add_field(f, :data_field_201, :string, df201)
 
-      df202 = { function: 'missing_fun', then: 'addClass red', target: '#post_data_field_202_input label' }
+      df202 = { function: 'missing_fun', then: 'addClass', args: 'red', target: '#post_data_field_202_input label' }
       add_field(f, :data_field_202, :string, df202)
 
       df203 = { function: 'test_fun2' }
       add_field(f, :data_field_203, :boolean, df203)
 
       # --- addClass
-      df211 = { if: 'checked', then: 'addClass red', target: '#post_data_field_211_input label' }
+      df211 = { if: 'checked', then: 'addClass', args: 'red', target: '#post_data_field_211_input label' }
       add_field(f, :data_field_211, :boolean, df211)
 
       # --- callback
-      df221 = { if: 'checked', then: 'callback test_callback', args: 'test_callback_arg' }
+      df221 = { if: 'checked', then: 'callback', args: 'test_callback' }
       add_field(f, :data_field_221, :boolean, df221)
 
-      df222 = { if: 'checked', then: 'callback missing_callback', args: 'callback arg' }
+      df222 = { if: 'checked', then: 'callback', args: 'missing_callback' }
       add_field(f, :data_field_222, :boolean, df222)
 
       # --- setValue
-      df231 = { if: 'checked', then: 'setValue data test', target: '#post_data_test' }
+      df231 = { if: 'checked', then: 'setValue', args: 'data test', target: '#post_data_test' }
       add_field(f, :data_field_231, :boolean, df231)
 
       # --- hide
@@ -150,23 +150,30 @@ ActiveAdmin.register Post do
       add_field(f, :data_field_261, :boolean, df261)
 
       # --- setText
-      df271 = { if: 'checked', then: 'setText data test', target: '#post_data_field_271_input .inline-hints' }
+      df271 = { if: 'checked', then: 'setText', args: 'data test', target: '#post_data_field_271_input .inline-hints' }
       add_field(f, :data_field_271, :boolean, df271)
 
       # --- addStyle
-      df281 = { if: 'checked', then: 'addStyle font-size: 10px; padding: 3px', target: '#post_data_field_281' }
+      df281 = { if: 'checked', then: 'addStyle', args: 'font-size: 10px; padding: 3px', target: '#post_data_field_281' }
       add_field(f, :data_field_281, :boolean, df281, {}, { 'style': 'margin-right: 20px' })
 
       # --- gtarget
-      df301 = { if: 'checked', then: 'addClass red', gtarget: 'body.active_admin' }
+      df301 = { if: 'checked', then: 'addClass', args: 'red', gtarget: 'body.active_admin' }
       add_field(f, :data_field_301, :boolean, df301)
 
       # This will not work - here only for testing:
-      df302 = { if: 'checked', then: 'addClass red', target: 'body.active_admin' }
+      df302 = { if: 'checked', then: 'addClass', args: 'red', target: 'body.active_admin' }
       add_field(f, :data_field_302, :boolean, df302)
 
       # --- else
-      df321 = { if: 'checked', then: 'addClass red', target: '#post_data_field_321_input label', else: 'addClass green' }
+      df321 = {
+        if: 'checked',
+        then: 'addClass',
+        args: 'red',
+        target: '#post_data_field_321_input label',
+        else: 'addClass',
+        else_args: 'green'
+      }
       add_field(f, :data_field_321, :boolean, df321)
     end
 

--- a/spec/system/dynamic_fields_spec.rb
+++ b/spec/system/dynamic_fields_spec.rb
@@ -119,11 +119,10 @@ RSpec.describe 'Dynamic fields', type: :system do
       test_set_css('#post_data_field_211_input label.red', action: [:click, '#post_data_field_211'])
 
       # --- callback
-      # TODO: fix me
-      # spec_message('check data-then="callback ..." action')
-      # test_set_css('body.test_callback_arg', one_way: true, action: [:click, '#post_data_field_221'])
-      # find('#post_data_field_222').click
-      # expect(page).to have_css('#post_data_field_222[data-df-errors="callback function not found"]')
+      spec_message('check data-then="callback ..." action')
+      test_set_css('body.some_class', one_way: true, action: [:click, '#post_data_field_221'])
+      find('#post_data_field_222').click
+      expect(page).to have_css('#post_data_field_222[data-df-errors="callback function not found"]')
 
       # --- setValue
       spec_message('check data-then="setValue ..." action')

--- a/spec/system/dynamic_fields_spec.rb
+++ b/spec/system/dynamic_fields_spec.rb
@@ -69,7 +69,8 @@ RSpec.describe 'Dynamic fields', type: :system do
     it 'checks the conditions and actions', retry: 3 do # rubocop:disable RSpec/ExampleLength, RSpec/MultipleExpectations
       visit "/admin/posts/#{post.id}/edit"
 
-      expect(page).to have_css('#post_data_field_111[data-if="checked"][data-then="addClass red"][data-target="#post_data_field_111_input label"]')
+      data = '[data-if="checked"][data-then="addClass"][data-args="red"][data-target="#post_data_field_111_input label"]'
+      expect(page).to have_css("#post_data_field_111#{data}")
 
       # --- if
       spec_message('check data-if condition')
@@ -118,10 +119,11 @@ RSpec.describe 'Dynamic fields', type: :system do
       test_set_css('#post_data_field_211_input label.red', action: [:click, '#post_data_field_211'])
 
       # --- callback
-      spec_message('check data-then="callback ..." action')
-      test_set_css('body.test_callback_arg', one_way: true, action: [:click, '#post_data_field_221'])
-      find('#post_data_field_222').click
-      expect(page).to have_css('#post_data_field_222[data-df-errors="callback function not found"]')
+      # TODO: fix me
+      # spec_message('check data-then="callback ..." action')
+      # test_set_css('body.test_callback_arg', one_way: true, action: [:click, '#post_data_field_221'])
+      # find('#post_data_field_222').click
+      # expect(page).to have_css('#post_data_field_222[data-df-errors="callback function not found"]')
 
       # --- setValue
       spec_message('check data-then="setValue ..." action')


### PR DESCRIPTION
⚠️ **Breaking changes** ⚠️ 
- actions arguments now must be placed in _args_ key
  - example `data: { if: "checked", then: "addClass", args: "red", target: "#something" }`
- callbacks functions now must be placed in _callback_ key, optionally with arguments in _args_ key
  - example `data: { if: "checked", then: "callback", callback: "setTitle", args: "Some title" }`